### PR TITLE
ndot yaml updated

### DIFF
--- a/helix-configs/index/ndot.yaml
+++ b/helix-configs/index/ndot.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 indices:
   site:
     exclude:
@@ -30,6 +30,10 @@ indices:
         select: none
         value: |
           parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      navOrder:
+        select: head > meta[name="nav-order"]
+        value: |
+          attribute(el, 'content')
   search:
     exclude:
       - tools/**


### PR DESCRIPTION
nav order property added to query-index.json to the NDOT site

Test URLs:
- Before: https://main--stateofnebraska-aem--ociostateofnebraska.aem.live/
- After: https://ndot-query-yaml-update--stateofnebraska-aem--ociostateofnebraska.aem.live/
