### PR TITLE
Narrator announce "graphic" after the h1 element bug fix

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -36,7 +36,7 @@ export default function decorate( block ) {
 			<path class="usa-hero__svg-mid" d="M0,72c107.9,2.9,275.1,3.8,479.7-10.3C801.6,39.5,922.6.5,1159.3-.1c133.6-.4,328.7,11.4,567.7,72.1v14.9H0v-14.9Z"/>
 		</svg>
 	`;
-	const svgDiv = div( { class: 'usa-hero__svg' } );
+	const svgDiv = div( { class: 'usa-hero__svg', 'aria-hidden': true } );
 	svgDiv.innerHTML = svg;
 
 	block.innerText = '';


### PR DESCRIPTION
From the ADA team:

`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1727 86" preserveAspectRatio="none">`
This is the opening tag of the SVG icon that seems to be causing Narrator to announce "graphic" after the h1 element on
each page of the CMS sites.


Test URLs:
- Before: https://main--stateofnebraska-aem--ociostateofnebraska.aem.live/
- After: https://b-1486-hero-svg--stateofnebraska-aem--ociostateofnebraska.aem.live/
